### PR TITLE
Test that sends a message to Qxf2's Skype sender  

### DIFF
--- a/skype-sender-exercise/Readme.md
+++ b/skype-sender-exercise/Readme.md
@@ -1,10 +1,10 @@
 You can use this test to send messages to skype channel:
 
-### Prerequisites to run the tests###
+### Prerequisites to run the test###
 1. Set the following environment variables :
 
    SKYPE_CHANNEL_ID # Skype channel id
    API_KEY # API secret key
 
-### Run the tests###
+### How to run the test###
 1. run `pytest` command at the root directory

--- a/skype-sender-exercise/Readme.md
+++ b/skype-sender-exercise/Readme.md
@@ -1,0 +1,10 @@
+You can use this test to send messages to skype channel:
+
+### Prerequisites to run the tests###
+1. Set the following environment variables :
+
+   SKYPE_CHANNEL_ID # Skype channel id
+   API_KEY # API secret key
+
+### Run the tests###
+1. run `pytest` command at the root directory

--- a/skype-sender-exercise/conf/skype_conf.py
+++ b/skype-sender-exercise/conf/skype_conf.py
@@ -1,0 +1,6 @@
+"""
+Specify the API_KEY and SKYPE_CHANNEL_ID needed for skype sender endpoint
+"""
+
+API_KEY = 'ADD API_KEY HERE'
+SKYPE_CHANNEL_ID = 'ADD SKYPE_CHANNEL_ID HERE'

--- a/skype-sender-exercise/requirements.txt
+++ b/skype-sender-exercise/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.27.1
+pytest==6.2.3

--- a/skype-sender-exercise/tests/test_skype_send_message.py
+++ b/skype-sender-exercise/tests/test_skype_send_message.py
@@ -1,0 +1,22 @@
+"""
+Test to send a message to skype channel using "/send-message" endpoint of Skype sender
+
+"""
+import json
+import requests
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from conf import skype_conf as creds
+
+SKYPE_ENDPOINT = 'https://skype-sender.qxf2.com/send-message'
+
+def test_skype_send_message():    
+    msg = "Hi, This is a message from Indira"
+    data = json.dumps({"msg": msg, "channel": creds.SKYPE_CHANNEL_ID, "API_KEY": creds.API_KEY})    
+    headers = {'Content-Type': 'application/json'}  
+    response = requests.post(SKYPE_ENDPOINT, headers=headers, data=data)    
+    print (response.status_code)
+
+#---START OF SCRIPT
+if __name__ == '__main__':    
+    test_skype_send_message()

--- a/skype-sender-exercise/tests/test_skype_send_message.py
+++ b/skype-sender-exercise/tests/test_skype_send_message.py
@@ -1,5 +1,5 @@
 """
-Test to send a message to skype channel using "/send-message" endpoint of Skype sender
+Test to send a message to skype channel using "/send-message" endpoint of Qxf2's Skype sender
 
 """
 import json
@@ -10,7 +10,8 @@ from conf import skype_conf as creds
 
 SKYPE_ENDPOINT = 'https://skype-sender.qxf2.com/send-message'
 
-def test_skype_send_message():    
+def test_skype_send_message():   
+    "Send the given message" 
     msg = "Hi, This is a message from Indira"
     data = json.dumps({"msg": msg, "channel": creds.SKYPE_CHANNEL_ID, "API_KEY": creds.API_KEY})    
     headers = {'Content-Type': 'application/json'}  


### PR DESCRIPTION
**Summary**

Added test to send a message to given channel

**Description and Contents**

This PR consists test, conf file, Readme.md, requirements.txt

**Testing**

If you want run this test, follow below steps:
* add your `API_KEY` and `SKYPE_CHANNEL_ID` in the conf/skype_conf.py file under skype-sender-exercise folder. 
* run using `python tests/test_skype_send_message.py`

**Results**

A message will be sent to the given skype channel:

`Qxf2Bot, 12:18`

`Hi, This is a message from Indira`